### PR TITLE
Fix black background for ghostty non black black

### DIFF
--- a/tclock.go
+++ b/tclock.go
@@ -39,7 +39,7 @@ type Config struct {
 	radius      float64         // radius of the disc around the time in proportion of the time width
 	fillBlack   bool            // whether to fill the screen with black before drawing discs
 	aliasing    float64         // aliasing factor for the disc drawing
-	blackBG     string
+	blackBG     string          // ANSI sequence for the black background: either 16 basic (color 0) or RGB black (truecolor).
 }
 
 func bounce(frame, maximum int) int {


### PR DESCRIPTION
```
 tclock -color-disc 1020ff -breath
```

was looking like:

<img width="262" height="217" alt="Screenshot 2025-08-19 at 2 05 53 PM" src="https://github.com/user-attachments/assets/de744de0-7c0e-401a-87c9-3212027f0397" />


on ghostty's default term/config because black isn't black in that theme

fixed

<img width="248" height="163" alt="Screenshot 2025-08-19 at 2 06 29 PM" src="https://github.com/user-attachments/assets/8280dbd5-2e53-4de9-879a-45cb35f1515e" />
