### PR TITLE
Avoid some color bleeding (from leftover background colors) and gaps with apple terminal. add ColorState to skip out noop color changes (to be moved to ansipixels later)

### DIFF
--- a/analog.go
+++ b/analog.go
@@ -54,7 +54,7 @@ func drawLine(pix Pixels, sx, sy, x0i, y0i int, color tcolor.RGBColor) {
 }
 
 // ColorState remembers last set foreground/background colors.
-// TODO: move this into ansipixels (optimize settiung fg/bg only when needed).
+// TODO: move this into ansipixels (optimize setting fg/bg only when needed).
 type ColorState struct {
 	fg, bg tcolor.RGBColor
 }


### PR DESCRIPTION
One key characteristic of what we aim is smallest amount of bytes sent for a given rendering (note we should also optimize the cursor moves like we do in image showing and disc)

before

<img width="158" height="196" alt="Screenshot 2025-10-12 at 4 55 33 PM" src="https://github.com/user-attachments/assets/49ea03e0-0f25-45c8-9c59-229718aa235c" />


after

<img width="211" height="227" alt="Screenshot 2025-10-12 at 4 55 57 PM" src="https://github.com/user-attachments/assets/c916da92-c07d-4222-b068-6f434886dacb" />
