### PR TITLE
Add missing start/end syncmode in OnResize

### DIFF
--- a/tclock.go
+++ b/tclock.go
@@ -448,7 +448,9 @@ func RawModeLoop(cfg *Config) int {
 	prev := ""
 	ap.OnResize = func() error {
 		cfg.ClearScreen()
+		cfg.ap.StartSyncMode()
 		cfg.DrawAt(-1, -1, TimeString(prev, false))
+		cfg.ap.EndSyncMode()
 		return nil
 	}
 	for {


### PR DESCRIPTION
ansipixels 0.60.2 fixed a bogus extra end but this mistakenly relied on it